### PR TITLE
feat: add a docker image for reproducible game extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7.15-jessie
+
+RUN pip install Pillow numpy
+
+COPY *.py /darkfo/
+COPY lut/* /darkfo/lut/
+
+VOLUME ["/output","/game"]
+
+ENTRYPOINT cd /output && cp -r /darkfo/lut/ .  && python /darkfo/setup.py /game/


### PR DESCRIPTION
I tried the `setup.py` but had some errors and wasn't sure if they were just warning.

This is a docker image for replicable extraction of game data.

In order to use it (replace variables if needed):
```
GAME_FOLDER="$HOME/PlayOnLinux\'s\ virtual\ drives/Fallout2_gog/drive_c/GOG\ Games/Fallout\ 2/"
OUTPUT="/tmp/"

docker build . -t darkfo:extractor
docker run -v $GAME_FOLDER:/game/ -v $OUTPUT:/output/ -ti darkfo:extractor
```

For reference, this is the output on my machine https://gist.github.com/Allsimon/bcd31c5bbce9589ab993c134671c3ab3


